### PR TITLE
Adjust single-entry name case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning].
 
 
 ## [Unreleased]
-- /
+- entry name case now consistent across all snippets
 
 
 ## [1.2.0] - 2021-07-30

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,12 +205,12 @@ export function activate(): void {
                     documentation: new vscode.MarkdownString(clEntries.value.replace('- $0', '')),
                     insertText: clEntries
                 },
-                entrySnippet('ADDED'),
-                entrySnippet('CHANGED'),
-                entrySnippet('DEPRECATED'),
-                entrySnippet('REMOVED'),
-                entrySnippet('FIXED'),
-                entrySnippet('SECURITY'),
+                entrySnippet('Added'),
+                entrySnippet('Changed'),
+                entrySnippet('Deprecated'),
+                entrySnippet('Removed'),
+                entrySnippet('Fixed'),
+                entrySnippet('Security'),
                 {
                     label: 'cl-link-first',
                     kind: vscode.CompletionItemKind.Snippet,


### PR DESCRIPTION
Entry headers were either all uppercase for a single entry snippet (e.g. ADDED) or not for all other snippets (e.g. Added).
This commit replaces the all uppercase entries for a more consistent view across all snippets.