### PR TITLE
Add versionPrefix config property

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
 					"description": "The prefix to use for version tags in the changelog.",
 					"type": "string",
 					"default": "v"
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -90,11 +90,11 @@
           "type": "string",
           "default": ""
         },
-				"keep-a-changelog.versionPrefix": {
-					"title": "Version Tag Prefix",
-					"description": "The prefix to use for version tags in the changelog.",
-					"type": "string",
-					"default": "v"
+        "keep-a-changelog.versionPrefix": {
+          "title": "Version Tag Prefix",
+          "description": "The prefix to use for version tags in the changelog.",
+          "type": "string",
+          "default": "v"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -89,7 +89,12 @@
           "description": "The default repository used for URLs within the changelog.\nIf empty, it will use tab-completion within the snippet.\nCan be overriden via workspace settings.",
           "type": "string",
           "default": ""
-        }
+        },
+				"keep-a-changelog.versionPrefix": {
+					"title": "Version Tag Prefix",
+					"description": "The prefix to use for version tags in the changelog.",
+					"type": "string",
+					"default": "v"
       }
     }
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ type Config = {
     dateData: DateData;
     defaultAuthor: string;
     defaultRepository: string;
+    versionPrefix: string
 };
 
 function formatDate(config: vscode.WorkspaceConfiguration): DateData {
@@ -65,6 +66,7 @@ export function parseConfig(): Config {
         triggerCharacter: config.get('triggerCharacter', true),
         dateData: formatDate(config),
         defaultAuthor: config.get('defaultAuthor', ''),
-        defaultRepository: config.get('defaultRepository', '')
+        defaultRepository: config.get('defaultRepository', ''),
+        versionPrefix: config.get('versionPrefix', 'v')
     };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,7 @@ function getRepository(repo: string, index: number): string {
 }
 
 export function activate(): void {
-    const { validFiles, untitledFile, triggerCharacter, dateData, defaultAuthor, defaultRepository } = parseConfig();
+    const { validFiles, untitledFile, triggerCharacter, dateData, defaultAuthor, defaultRepository, versionPrefix } = parseConfig();
     const { dateDisplay, dateEditable, dateFix } = dateData;
 
     const completionProvider: vscode.CompletionItemProvider<vscode.CompletionItem> = {
@@ -149,15 +149,15 @@ export function activate(): void {
                     `[unreleased]: https://github.com/${getAuthor(defaultAuthor, 1)}/${getRepository(
                         defaultRepository,
                         2
-                    )}/compare/v0.0.2...HEAD`,
+                    )}/compare/${versionPrefix}0.0.2...HEAD`,
                     `[0.0.2]: https://github.com/${getAuthor(defaultAuthor, 1)}/${getRepository(
                         defaultRepository,
                         2
-                    )}/compare/v0.0.1...v0.0.2`,
+                    )}/compare/${versionPrefix}0.0.1...${versionPrefix}0.0.2`,
                     `[0.0.1]: https://github.com/${getAuthor(defaultAuthor, 1)}/${getRepository(
                         defaultRepository,
                         2
-                    )}/releases/tag/v0.0.1`
+                    )}/releases/tag/${versionPrefix}0.0.1`
                 ])
             );
 
@@ -217,7 +217,7 @@ export function activate(): void {
                         `[\${1:Version}]: https://github.com/${getAuthor(defaultAuthor, 2)}/${getRepository(
                             defaultRepository,
                             3
-                        )}/releases/v\${1:Version}$0`
+                        )}/releases/${versionPrefix}\${1:Version}$0`
                     )
                 },
                 {
@@ -231,7 +231,7 @@ export function activate(): void {
                         `[\${1:Version}]: https://github.com/${getAuthor(defaultAuthor, 2)}/${getRepository(
                             defaultRepository,
                             3
-                        )}/compare/v\${4:PreviousVersion}..v\${1:Version}$0`
+                        )}/compare/${versionPrefix}\${4:PreviousVersion}..${versionPrefix}\${1:Version}$0`
                     )
                 }
             );


### PR DESCRIPTION
I added an option to set a tag version prefix (default "v") for when the user doesn't append `v` to the version name or uses another prefix. (such as 1.0.0 or  legacy-1.0.0 instead of v1.0.0)

This only concerns the snippets `cl-link-compare` and `cl-link-first`

I tested it and it's working as expected.